### PR TITLE
IvyResolver should be M2 compatible if Resolver.mavenStylePatterns is used

### DIFF
--- a/src/main/scala/SBTS3Resolver.scala
+++ b/src/main/scala/SBTS3Resolver.scala
@@ -63,6 +63,8 @@ object SbtS3Resolver extends Plugin {
         , credentials._2 //secretKey
         )
 
+      if (patterns.isMavenCompatible) r.setM2compatible(true)
+
       def withBase(pattern: String): String = 
         if(url.endsWith("/") || pattern.startsWith("/")) url + pattern 
         else url + "/" + pattern


### PR DESCRIPTION
The issue is that ohnosequences.ivy.S3Resolver is expected to create directory structure com/foo/bar for organisation 'com.foo.bar', otherwise it will not be compatible with maven. IvyResolver should be M2 compatible if Resolver.mavenStylePatterns is used. I tested it with sbt0.3 and it seems to work. This is a very simple change
