### PR TITLE
Put everithing into some package namespace

### DIFF
--- a/src/main/scala/SBTS3Resolver.scala
+++ b/src/main/scala/SBTS3Resolver.scala
@@ -1,3 +1,5 @@
+package ohnosequences.sbt
+
 import sbt._
 import Keys._
 import com.amazonaws.services.s3.model.Region;


### PR DESCRIPTION
One of the sbt "Plugins Best Practices" sounds like:

> Avoid namespace clashes

So I'm adding `ohnosequences.sbt` namespace. In addition, without package in this plugin, you can't import it in a plugin, which has package (at least I didn't figure out how to do that). 
