### PR TITLE
Validate s3credentialsFile and fall back to DefaultAWSCredentialsProviderChain

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,8 @@ s3credentialsFile := Some("/funny/absolute/path/to/credentials.properties")
 
 and don't forget to **add it to you `.gitignore`** file, so that you won't publish this file anywhere.
 
+If you don't set the `s3credentialsFile` setting to a valid file, the plugin will try to lookup the credentials using the [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) class provided by the AWS Java SDK.
+
 The file with actual credentials should contain the access key and secret key of your AWS account (or that of an IAM user), in the following format:
 
 ```

--- a/src/main/scala/SBTS3Resolver.scala
+++ b/src/main/scala/SBTS3Resolver.scala
@@ -1,17 +1,27 @@
 package ohnosequences.sbt
 
 import sbt._
-import Keys._
-import com.amazonaws.services.s3.model.Region;
+import com.amazonaws.services.s3.model.Region
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.AmazonClientException
+import scala.tools.nsc.io.File
 
 object SbtS3Resolver extends Plugin {
 
+  private lazy val defaultAWSCredentialsProviderChain = new DefaultAWSCredentialsProviderChain()
+
   type S3Credentials = (String, String)
+
+  private lazy val fileCredentials =
+    SettingKey[Option[S3Credentials]]("AWS credentials from s3-credentials-file")
+
+  private lazy val defaultChainCredentials =
+    SettingKey[Option[S3Credentials]]("AWS credentials from instance profile")
 
   lazy val s3credentialsFile = 
     SettingKey[Option[String]]("s3-credentials-file", 
       "properties format file with amazon credentials to access S3")
- 
+
   lazy val s3credentials = 
     SettingKey[Option[S3Credentials]]("s3-credentials", 
       "S3 credentials accessKey and secretKey")
@@ -87,7 +97,38 @@ object SbtS3Resolver extends Plugin {
 
   // default values
   override def settings = Seq(
+
     s3credentialsFile := None
-  , s3credentials     <<= s3credentialsFile (s3credentialsParser)
+
+    /**
+     * Attempts to read the credentials from the `s3credentialsFile` if set
+     */
+  , fileCredentials <<= s3credentialsFile { pathOpt =>
+      val validPath = pathOpt.filter { path =>
+        File(path).canRead
+      }
+      s3credentialsParser(validPath)
+    }
+
+    /**
+     * Attempts for fetch the credentials using the `DefaultAWSCredentialsProviderChain`
+     * class provided by the AWS SDK
+     */
+  , defaultChainCredentials := {
+      try {
+        val awsCredentials = defaultAWSCredentialsProviderChain.getCredentials
+        Some((awsCredentials.getAWSAccessKeyId, awsCredentials.getAWSSecretKey))
+      } catch {
+        case e: AmazonClientException => None
+      }
+    }
+
+    /**
+     * Gets the credentials from `s3credentialsFile`, falling back to
+     * `defaultChainCredentials`
+     */
+  , s3credentials <<= (fileCredentials, defaultChainCredentials) { (fc, cc) =>
+      fc orElse cc
+    }
   )
 } 


### PR DESCRIPTION
Added some functionality to validate the readability of the file set in `s3credentialsFile`, plus fall back to `DefaultAWSCredentialsProviderChain` if the credentials cannot be read from the file. This makes possible to lookup the credentials provided by the IAM instance profile on an EC2 instance.
