### PR TITLE
https by default for resolvers

### DIFF
--- a/src/main/scala/SBTS3Resolver.scala
+++ b/src/main/scala/SBTS3Resolver.scala
@@ -18,13 +18,13 @@ object SbtS3Resolver extends Plugin {
   lazy val showS3Credentials = TaskKey[Unit]("showS3Credentials", "Just outputs credentials that are loaded by the s3credentials provider")
 
   // S3 bucket url
-  case class s3(region: String, url: String) {
+  case class s3(url: String) {
     // adds 's3://' prefix if it was not there
     override def toString: String = "s3://" + url.stripPrefix("s3://")
     
     // convenience method, to use normal bucket addresses with `at`
-    // without this resolver: "foo" at s3(s3region.value, "maven.bucket.com")
-    def toHttps: String = s"""https://s3-${region}.amazonaws.com/${url.stripPrefix("s3://")}"""
+    // without this resolver: "foo" at s3("maven.bucket.com").toHttps(s3region.value)
+    def toHttps(region: String): String = s"""https://s3-${region}.amazonaws.com/${url.stripPrefix("s3://")}"""
   }
 
   case class S3Resolver

--- a/src/main/scala/SBTS3Resolver.scala
+++ b/src/main/scala/SBTS3Resolver.scala
@@ -18,13 +18,13 @@ object SbtS3Resolver extends Plugin {
   lazy val showS3Credentials = TaskKey[Unit]("showS3Credentials", "Just outputs credentials that are loaded by the s3credentials provider")
 
   // S3 bucket url
-  case class s3(url: String) {
+  case class s3(region: String, url: String) {
     // adds 's3://' prefix if it was not there
     override def toString: String = "s3://" + url.stripPrefix("s3://")
     
     // convenience method, to use normal bucket addresses with `at`
-    // without this resolver: "foo" at s3("maven.bucket.com").toHttp
-    def toHttp: String = "http://"+url.stripPrefix("s3://")+".s3.amazonaws.com"
+    // without this resolver: "foo" at s3(s3region.value, "maven.bucket.com")
+    def toHttps: String = s"""https://s3-${region}.amazonaws.com/${url.stripPrefix("s3://")}"""
   }
 
   case class S3Resolver


### PR DESCRIPTION
This can be a bit tricky due to S3 endpoints, but it is much needed for security reasons. I got it working here

- [scarph plugins.sbt](https://github.com/ohnosequences/scarph/blob/e0f0b798b0a96c165a1fa5f3a6689c9a83a47843/project/plugins.sbt)

The pattern should be

``` scala
val resolverURL = s"https://s3-${region}.amazonaws.com/${bucket}"
```

The list of endpoints is here: [AWS general reference - S3 endpoints](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). We should create a sealed region trait and specify it as a setting.