### PR TITLE
Update to ivy-s3-resolver with the redundant delimiters fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,18 @@
 sbtPlugin := true
 
-name := "sbt-s3-resolver"
+name         := "sbt-s3-resolver"
 organization := "ohnosequences"
-description := "SBT plugin which provides Amazon S3 bucket resolvers"
+description  := "SBT plugin which provides Amazon S3 bucket resolvers"
 
-javaVersion := "1.8"
+javaVersion  := "1.8"
 scalaVersion := "2.12.3"
-sbtVersion := "1.0.1"
+sbtVersion   := "1.0.2"
 
 bucketSuffix := "era7.com"
 
-resolvers += Resolver.bintrayRepo("ohnosequences", "maven")
+resolvers += Resolver.jcenterRepo
 
-libraryDependencies += "ohnosequences" % "ivy-s3-resolver" % "0.11.0"
+libraryDependencies += "ohnosequences" % "ivy-s3-resolver" % "0.12.0"
 
 dependencyOverrides ++= Set(
   "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
@@ -21,9 +21,9 @@ dependencyOverrides ++= Set(
 
 wartremoverErrors in (Compile, compile) --= Seq(Wart.Any, Wart.NonUnitStatements)
 
-bintrayReleaseOnPublish := true
-bintrayOrganization := Some(organization.value)
-bintrayPackageLabels := Seq("sbt-plugin", "s3", "resolver")
+bintrayReleaseOnPublish := !isSnapshot.value
+bintrayOrganization     := Some(organization.value)
+bintrayPackageLabels    := Seq("sbt-plugin", "s3", "resolver")
 
 publishMavenStyle := false
 publishTo := (publishTo in bintray).value

--- a/notes/0.17.0.markdown
+++ b/notes/0.17.0.markdown
@@ -2,3 +2,9 @@
 * #25: Published to Bintray community repository
 * #35: Added storage class setting
 * Upgraded to [ivy-s3-resolver v0.11.0](https://github.com/ohnosequences/ivy-s3-resolver/releases/tag/v0.11.0)
+
+----
+
+#### IMPORTANT
+
+**This release is affected by the problem with redundant delimiters the ivy-style patterns introduced in sbt 1.0 (see [sbt/sbt#3573](https://github.com/sbt/sbt/issues/3573)). You are strongly recommended to update to the next version which contains a fix for it.**

--- a/notes/changelog.md
+++ b/notes/changelog.md
@@ -1,0 +1,5 @@
+This is a bugfix release, it updates to [ivy-s3-resolver v0.12.0](https://github.com/ohnosequences/ivy-s3-resolver/releases/tag/v0.12.0) which solves the problem with redundant delimiters the ivy-style patterns introduced in sbt 1.0 (see [sbt/sbt#3573](https://github.com/sbt/sbt/issues/3573)).
+
+The problem was reported and handled in the underlying library by Michael Ahlers @michaelahlers:
+* [ohnosequences/sbt-s3-resolver#52](https://github.com/ohnosequences/sbt-s3-resolver/issues/52)
+* [ohnosequences/ivy-s3-resolver#19](https://github.com/ohnosequences/ivy-s3-resolver/pull/19)


### PR DESCRIPTION
Fixes #52.

See https://github.com/ohnosequences/ivy-s3-resolver/pull/19 by @michaelahlers.